### PR TITLE
- [x] Mensaje al configurar nuevo URL para que reinicie el app

### DIFF
--- a/lib/localization/app_locale.dart
+++ b/lib/localization/app_locale.dart
@@ -31,6 +31,7 @@ class AppLocale {
   static const String selectRole = 'selectRole';
   static const String company = 'company';
   static const String role = 'role';
+  static const String taxIDOrName = 'taxIDOrName';
   static const String organization = 'organization';
   static const String selectCompanyRoleOrganization =
       'selectCompanyRoleOrganization';
@@ -89,6 +90,7 @@ class AppLocale {
   static const String code = 'code';
   static const String name = 'name';
   static const String description = 'description';
+  static const String upc = 'upc';
   static const String priceKey = 'priceKey';
   static const String stockKey = 'stockKey';
   static const String category = 'category';
@@ -173,6 +175,7 @@ class AppLocale {
     rememberMe: 'Remember Me',
     server: 'Server',
     lang: 'Language',
+    upc: 'UPC',
     newOrder: 'New Order',
     customer: 'Customer',
     process: 'Process',
@@ -185,8 +188,9 @@ class AppLocale {
         'Please select a company, role, and organization',
     continueKey: 'Continue',
     back: 'Back',
+    taxIDOrName: 'ID or Name...',
     invalidCredentials: 'Invalid credentials',
-    serverSaved: 'Server address saved.',
+    serverSaved: 'Server address saved. Please restart the app',
     customers: 'Customers',
     searchCustomer: 'Search customer',
     add: 'Add',
@@ -318,12 +322,15 @@ class AppLocale {
     selectRole: 'Seleccionar Rol',
     company: 'Empresa',
     role: 'Rol',
+    upc: 'UPC',
     organization: 'Organización',
     selectCompanyRoleOrganization: 'Seleccione una empresa, rol y organización',
     continueKey: 'Continuar',
     back: 'Volver',
+    taxIDOrName: 'Identificación o Nombre...',
     invalidCredentials: 'Credenciales incorrectas',
-    serverSaved: 'Se guardó la dirección del servidor.',
+    serverSaved:
+        'Se guardó la dirección del servidor. Por favor reiniciar el app',
     customers: 'Clientes',
     searchCustomer: 'Buscar cliente',
     add: 'Agregar',

--- a/lib/shared/custom_textfield.dart
+++ b/lib/shared/custom_textfield.dart
@@ -68,7 +68,7 @@ class _TextfieldThemeState extends State<TextfieldTheme> {
       decoration: InputDecoration(
         counterText: '',
         hintText: widget.pista,
-        hintStyle: TextStyle(color: Theme.of(context).colorScheme.secondary),
+        hintStyle: TextStyle(color: Colors.grey),
         filled: true, // Habilita el relleno del fondo
         fillColor: Theme.of(context).cardColor,
         hoverColor: Theme.of(context).primaryColor.withAlpha(40),

--- a/lib/views/Auth/login_view.dart
+++ b/lib/views/Auth/login_view.dart
@@ -162,11 +162,11 @@ class _LoginPageState extends State<LoginPage> {
         return AlertDialog(
           title: Text(
             AppLocale.server.getString(context),
-            style: Theme.of(context).textTheme.bodyLarge,
+            style: Theme.of(context).textTheme.titleMedium,
           ),
           content: Text(
             AppLocale.serverSaved.getString(context),
-            style: Theme.of(context).textTheme.bodyMedium,
+            style: Theme.of(context).textTheme.bodyLarge,
           ),
           actions: [
             IconButton(

--- a/lib/views/Home/bpartner/bpartner_details.dart
+++ b/lib/views/Home/bpartner/bpartner_details.dart
@@ -8,7 +8,7 @@ import '../../../shared/custom_dropdown.dart';
 import '../../../shared/footer.dart';
 import '../../../shared/shimmer_list.dart';
 import '../../../shared/custom_textfield.dart';
-import '../../../theme/colors.dart';
+import '../../../shared/toast_message.dart';
 import 'bpartner_funtions.dart';
 import '../../../localization/app_locale.dart';
 
@@ -134,10 +134,6 @@ class _BPartnerDetailPageState extends State<BPartnerDetailPage> {
               onPressed: () => Navigator.pop(context, true),
               child: Text(
                 AppLocale.confirm.getString(context),
-                style: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(color: Theme.of(context).colorScheme.surface),
               ),
             ),
           ],
@@ -167,15 +163,16 @@ class _BPartnerDetailPageState extends State<BPartnerDetailPage> {
     setState(() => isLoading = false);
 
     if (result['success'] == true) {
-      Navigator.pop(context, true);
+      Navigator.pop(context, {
+        'created': true,
+        'bpartner': nameController.text,
+      });
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Center(
-              child: Text(result['message'] ??
-                  AppLocale.errorUpdateCustomer.getString(context))),
-          backgroundColor: ColorTheme.error,
-        ),
+      ToastMessage.show(
+        context: context,
+        message: result['message'] ??
+            AppLocale.errorUpdateCustomer.getString(context),
+        type: ToastType.failure,
       );
     }
   }
@@ -186,6 +183,11 @@ class _BPartnerDetailPageState extends State<BPartnerDetailPage> {
         appBar: AppBar(
           title: Text(AppLocale.customerDetail.getString(context)),
           centerTitle: true,
+          leading: IconButton(
+              onPressed: () => Navigator.pop(context, {
+                    'created': false,
+                  }),
+              icon: Icon(Icons.arrow_back)),
         ),
         bottomNavigationBar: CustomFooter(),
         body: SafeArea(

--- a/lib/views/Home/bpartner/bpartner_funtions.dart
+++ b/lib/views/Home/bpartner/bpartner_funtions.dart
@@ -315,8 +315,8 @@ Future<Map<String, dynamic>> putBPartner({
     // Actualizar C_BPartner primero
     final Map<String, dynamic> bpartnerData = {
       "Name": name,
-      if (taxID != null) "TaxID": taxID,
-      if (dv != null) "dv": dv,
+      if (taxID != null && taxID.isNotEmpty) "TaxID": taxID,
+      if (dv != null && dv.isNotEmpty) "dv": dv,
       "C_BP_Group_ID": {"id": cBPartnerGroupID},
       "LCO_TaxIdType_ID": {"id": cTaxTypeID},
       "TipoClienteFE": customerType,

--- a/lib/views/Home/bpartner/bpartner_new.dart
+++ b/lib/views/Home/bpartner/bpartner_new.dart
@@ -3,12 +3,12 @@ import 'package:flutter_localization/flutter_localization.dart';
 import 'package:primware/API/lpa_config.dart';
 import 'package:primware/shared/custom_container.dart';
 import 'package:primware/shared/custom_spacer.dart';
+import 'package:primware/shared/toast_message.dart';
 import '../../../shared/button.widget.dart';
 import '../../../shared/custom_dropdown.dart';
 import '../../../shared/footer.dart';
 import '../../../shared/shimmer_list.dart';
 import '../../../shared/custom_textfield.dart';
-import '../../../theme/colors.dart';
 import '../../../localization/app_locale.dart';
 import 'bpartner_funtions.dart';
 
@@ -58,12 +58,7 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
 
   Future<void> _loadTaxType() async {
     final fetchedTaxTypes = await getCTaxTypeID(context) ?? [];
-    /*if (fetchedTaxTypes != null) {
-      setState(() {
-        taxTypes = fetchedTaxTypes;
-        _isTaxTypeLoading = false;
-      });
-    }*/
+
     setState(() {
       taxTypes = fetchedTaxTypes;
       _isTaxTypeLoading = false;
@@ -73,12 +68,7 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
 
   Future<void> _loadBPartnerGroups() async {
     final fetchedGroups = await getCBPGroup(context) ?? [];
-    /*if (fetchedGroups != null) {
-      setState(() {
-        bPartnerGroups = fetchedGroups;
-        _isGroupLoading = false;
-      });
-    }*/
+
     setState(() {
       bPartnerGroups = fetchedGroups;
       _isGroupLoading = false;
@@ -143,10 +133,6 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
               onPressed: () => Navigator.pop(context, true),
               child: Text(
                 AppLocale.confirm.getString(context),
-                style: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(color: Theme.of(context).colorScheme.surface),
               ),
             ),
           ],
@@ -171,7 +157,6 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
     );
 
     setState(() => isLoading = false);
-//TODO devolver true desde cliente nuevo que viene desde el panel de clientes y no desde orden
     if (result['success'] == true) {
       clearPartnerFields();
       Navigator.pop(context, {
@@ -179,13 +164,11 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
         'bpartner': result['bpartner'],
       });
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Center(
-              child: Text(result['message'] ??
-                  AppLocale.errorCreateCustomer.getString(context))),
-          backgroundColor: ColorTheme.error,
-        ),
+      ToastMessage.show(
+        context: context,
+        message: result['message'] ??
+            AppLocale.errorCreateCustomer.getString(context),
+        type: ToastType.failure,
       );
     }
   }
@@ -198,7 +181,9 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
             AppLocale.newCustomer.getString(context),
           ),
           leading: IconButton(
-              onPressed: () => Navigator.pop(context, false),
+              onPressed: () => Navigator.pop(context, {
+                    'created': false,
+                  }),
               icon: Icon(Icons.arrow_back)),
         ),
         bottomNavigationBar: CustomFooter(),
@@ -227,7 +212,6 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
                     colorEmpty: nameController.text.isEmpty,
                     inputType: TextInputType.name,
                   ),
-
                   const SizedBox(height: CustomSpacer.medium),
                   _isGroupLoading
                       ? ShimmerList(
@@ -265,18 +249,6 @@ class _BPartnerNewPageState extends State<BPartnerNewPage> {
                               },
                             )
                           : const SizedBox(),
-                  // Mensaje de error si taxTypes está vacío
-                  /*if (_taxTypeError && !_isTaxTypeLoading)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 8.0, left: 12.0),
-                              child: Text(
-                                AppLocale.noTaxTypesAvailable.getString(context),
-                                style: TextStyle(
-                                  color: Colors.red,
-                                  fontSize: 12,
-                                ),
-                              ),
-                            ),*/
                   const SizedBox(height: CustomSpacer.medium),
                   TextfieldTheme(
                     controlador: taxController,

--- a/lib/views/Home/bpartner/bpartner_view.dart
+++ b/lib/views/Home/bpartner/bpartner_view.dart
@@ -24,8 +24,7 @@ class _BPartnerListPageState extends State<BPartnerListPage> {
   List<Map<String, dynamic>> _bpartners = [];
   bool _isLoading = true;
   bool isSearchLoading = false;
-  // ignore: prefer_final_fields
-  String _searchQuery = '';
+  String searchQuery = '';
   TextEditingController searchController = TextEditingController();
   Timer? _debounce;
 
@@ -76,7 +75,7 @@ class _BPartnerListPageState extends State<BPartnerListPage> {
         .where((bp) => bp['name']
             .toString()
             .toLowerCase()
-            .contains(_searchQuery.toLowerCase()))
+            .contains(searchQuery.toLowerCase()))
         .toList();
   }
 
@@ -85,14 +84,15 @@ class _BPartnerListPageState extends State<BPartnerListPage> {
       children: records.map((record) {
         return GestureDetector(
           onTap: () async {
-            final refreshed = await Navigator.push(
+            final result = await Navigator.push(
               context,
               MaterialPageRoute(
                 builder: (_) => BPartnerDetailPage(bpartner: record),
               ),
             );
-            if (refreshed == true) {
-              _fetchBPartners();
+            if (result['created'] == true) {
+              searchController.text = result['bpartner'];
+              _loadBPartner(showLoadingIndicator: true);
             }
           },
           child: Container(
@@ -115,7 +115,6 @@ class _BPartnerListPageState extends State<BPartnerListPage> {
     );
   }
 
-//TODO reemplazar el icono de resfrescar por el de lupa y que sea ese el que se usa para buscar en vez del bounce
   @override
   Widget build(BuildContext context) {
     return WillPopScope(
@@ -133,15 +132,16 @@ class _BPartnerListPageState extends State<BPartnerListPage> {
         floatingActionButton: FloatingActionButton(
           tooltip: AppLocale.add.getString(context),
           onPressed: () async {
-            bool refresh = await Navigator.push(
+            final result = await Navigator.push(
               context,
               MaterialPageRoute(
                 builder: (context) => const BPartnerNewPage(),
               ),
             );
 
-            if (refresh) {
-              _fetchBPartners();
+            if (result['created'] == true) {
+              searchController.text = result['bpartner']?['Name'];
+              _loadBPartner(showLoadingIndicator: true);
             }
           },
           child: const Icon(Icons.add),
@@ -160,19 +160,20 @@ class _BPartnerListPageState extends State<BPartnerListPage> {
                   Row(
                     children: [
                       Expanded(
-                        //TODO agregar el locate y el placeholder sea mas gris
                         child: TextfieldTheme(
                           texto: AppLocale.searchCustomer.getString(context),
                           controlador: searchController,
-                          pista: "Nro. Identificación o nombre...",
-                          onChanged: (_) => debouncedLoadBPartner(),
+                          pista: AppLocale.taxIDOrName.getString(context),
+                          onSubmitted: (_) =>
+                              _loadBPartner(showLoadingIndicator: true),
                         ),
                       ),
                       const SizedBox(width: CustomSpacer.small),
                       IconButton(
                         tooltip: AppLocale.refresh.getString(context),
-                        icon: const Icon(Icons.refresh),
-                        onPressed: _fetchBPartners,
+                        icon: const Icon(Icons.search),
+                        onPressed: () =>
+                            _loadBPartner(showLoadingIndicator: true),
                       ),
                     ],
                   ),

--- a/lib/views/Home/order/my_order.dart
+++ b/lib/views/Home/order/my_order.dart
@@ -150,7 +150,8 @@ class _OrderListPageState extends State<OrderListPage> {
 
   Widget _buildSubtypePill(Map<String, dynamic> order) {
     final sub = order['doctypetarget']?['subtype']?['id'];
-    final bool isReturn = sub == 'RM' && POS.docTypeRefundID != null;
+    final bool isReturn =
+        (sub == 'RM') || (order['doctypetarget']?['id'] == POS.docTypeRefundID);
 
     final Color baseColor = isReturn ? Colors.red : Colors.green;
     final Color bgColor = baseColor.withOpacity(0.12);
@@ -181,7 +182,6 @@ class _OrderListPageState extends State<OrderListPage> {
     );
   }
 
-//TODO quitar el boton de devolucion si no vienen por el CPOSID
   Widget _buildOrderList(List<Map<String, dynamic>> orders) {
     if (orders.isEmpty) {
       return Center(
@@ -190,7 +190,8 @@ class _OrderListPageState extends State<OrderListPage> {
     }
     return Column(
       children: orders.map((order) {
-        final bool isReturn = order['doctypetarget']?['subtype']?['id'] == 'RM';
+        final bool isReturn =
+            (order['doctypetarget']?['id'] == POS.docTypeRefundID);
         return GestureDetector(
           onTap: () async {
             final refreshed = await Navigator.push(
@@ -274,7 +275,7 @@ class _OrderListPageState extends State<OrderListPage> {
                       ),
                     ),
                   ];
-                  if (!isReturn) {
+                  if (isReturn == false && POS.isPOS == true) {
                     items.add(
                       PopupMenuItem<String>(
                         value: 'refund',

--- a/lib/views/Home/product/product_details.dart
+++ b/lib/views/Home/product/product_details.dart
@@ -192,6 +192,12 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                   child: Column(
                 children: [
                   TextfieldTheme(
+                    controlador: skuController,
+                    texto: AppLocale.code.getString(context),
+                    inputType: TextInputType.text,
+                  ),
+                  const SizedBox(height: CustomSpacer.medium),
+                  TextfieldTheme(
                     controlador: nameController,
                     texto: '${AppLocale.name.getString(context)}*',
                     colorEmpty: nameController.text.isEmpty,
@@ -199,14 +205,8 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                   ),
                   const SizedBox(height: CustomSpacer.medium),
                   TextfieldTheme(
-                    controlador: skuController,
-                    texto: AppLocale.code.getString(context),
-                    inputType: TextInputType.text,
-                  ),
-                  const SizedBox(height: CustomSpacer.medium),
-                  TextfieldTheme(
                     controlador: upcController,
-                    texto: AppLocale.description.getString(context),
+                    texto: AppLocale.upc.getString(context),
                     inputType: TextInputType.text,
                   ),
                   const SizedBox(height: CustomSpacer.medium),
@@ -261,18 +261,6 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                             });
                           },
                         ),
-                  // Mensaje de error si taxTypes está vacío
-                  /*if (_taxError && !_isTaxiesLoading)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 8.0, left: 12.0),
-                            child: Text(
-                              AppLocale.noTaxCategoryAvailable.getString(context),
-                              style: TextStyle(
-                                color: Colors.red,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ),*/
                   const SizedBox(height: CustomSpacer.medium),
                   TextfieldTheme(
                     controlador: priceController,
@@ -298,8 +286,7 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                             ? ButtonLoading(fullWidth: true)
                             : ButtonPrimary(
                                 fullWidth: true,
-                                texto:
-                                    AppLocale.updateProduct.getString(context),
+                                texto: AppLocale.save.getString(context),
                                 onPressed: _updateProduct,
                               )
                         : null,

--- a/lib/views/Home/product/product_new.dart
+++ b/lib/views/Home/product/product_new.dart
@@ -190,6 +190,12 @@ class _ProductNewPageState extends State<ProductNewPage> {
                   child: Column(
                 children: [
                   TextfieldTheme(
+                    controlador: skuController,
+                    texto: AppLocale.code.getString(context),
+                    inputType: TextInputType.text,
+                  ),
+                  const SizedBox(height: CustomSpacer.medium),
+                  TextfieldTheme(
                     controlador: nameController,
                     texto: '${AppLocale.name.getString(context)}*',
                     colorEmpty: nameController.text.isEmpty,
@@ -197,14 +203,8 @@ class _ProductNewPageState extends State<ProductNewPage> {
                   ),
                   const SizedBox(height: CustomSpacer.medium),
                   TextfieldTheme(
-                    controlador: skuController,
-                    texto: AppLocale.code.getString(context),
-                    inputType: TextInputType.text,
-                  ),
-                  const SizedBox(height: CustomSpacer.medium),
-                  TextfieldTheme(
                     controlador: upcController,
-                    texto: AppLocale.description.getString(context),
+                    texto: AppLocale.upc.getString(context),
                     inputType: TextInputType.text,
                   ),
                   const SizedBox(height: CustomSpacer.medium),
@@ -263,18 +263,6 @@ class _ProductNewPageState extends State<ProductNewPage> {
                             });
                           },
                         ),
-                  // Mensaje de error si taxTypes está vacío
-                  /*if (_taxError && !_isTaxiesLoading)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 8.0, left: 12.0),
-                            child: Text(
-                              AppLocale.noTaxCategoryAvailable.getString(context),
-                              style: TextStyle(
-                                color: Colors.red,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ),*/
                   const SizedBox(height: CustomSpacer.medium),
                   TextfieldTheme(
                     controlador: priceController,


### PR DESCRIPTION
- [x] En el menu y ordenes las devoluciones si vienen por CPOSId se identifican por el id del numero de documento y no por el subtipo de documento RM
- [x] Desde el listado de ordenes quitar el boton de devolucion si no vienen por el CPOSID
- [x] Desde clientes reemplazar el icono de resfrescar por el de lupa y que sea ese el que se usa para buscar en vez del bounce, al hacer clic en el icono o hacer enter dispara el proceso
- [x] Desde la búsqueda del client agregar el locate y el placeholder sea mas gris
- [x] devolver el cliente actualizado que viene desde el editar cliente
- [x] devolver el cliente nuevo que viene desde el crear cliente tanto al listado como desde ordenes
- [x] al hacer clic en la imagen que abra para cambiar el logo